### PR TITLE
Mention putting issue numbers in commit messages

### DIFF
--- a/docs/contributing/code/submittingchanges.md
+++ b/docs/contributing/code/submittingchanges.md
@@ -12,6 +12,8 @@ A good idea is to include the GitHub issue number in the format "\*/gh-1234-\*".
 
 Write it so other developers, and your future self, can understand what was changes and why.
 
+If the commit is related to one or more issues, mention the issue numbers in the commit message ("issue \#1234").
+
 ## 3. Rebase your branch before creating the PR
 
 A rebase makes sure the PR is up to date and has no merge conflicts. Please do a rebase and not just a merge, this gives a clean and readable commit history.


### PR DESCRIPTION
@frjo and others,

In Hypha's commit history, sometimes the relevant issue number(s) is included in commit messages and sometimes not.  The "Contributing" documentation only talks about putting issue numbers in the related PR, not in commit messages themselves.  

Therefore, this PR is both a proposal and a question: do we want to put issue numbers in the commit messages?  The proposed answer is: "yes" :-).

Including issue numbers in commit messages means the commit<->issue connection would be memorialized in the actual Git history, not just in GitHub's PR records (which are not part of the Git history).

Now, one *could* respond by pointing out that the issue tickets themselves are also only in GitHub, not in the Git history.  However, I think that's not relevant, for three reasons:

1. Ticket numbers tend to get mentioned in a wide variety of places, so if a ticket number is mentioned in the commit history, then a thread of relatedness can be drawn among all the places that mention that issue -- the issue tracker being just one of those places.
2. One can (and people sometimes do) download issues in CSV/JSON format for off-GitHub archiving and processing, so there can be a record of issues independently of GitHub.
3. In any case, even if the issues are only on GitHub and nowhere else, it's still very useful to be able to go from commit logs straight to issue tickets.  There is *no* record of PR numbers in Git history, after all --- except for the rare cases where someone mentions a PR number, as opposed to an issue number, in a commit message (which rarely happens; see [commit 3d2e02a16e](https://github.com/HyphaApp/hypha/commit/3d2e02a16e38894282ebf2f5f79eab405a61c784) in Hypha, for example: how would someone know which PR it's referring to?).  It's quite hard to go from the Git history to the corresponding issue tickets unless the tickets are explicitly named in the commit logs, and yet it is often *useful* to go from Git history to corresponding issues.

Therefore, let us make the history->issue jump possible.

Thoughts?